### PR TITLE
Use pkg-config to detect libdbusmenu directories

### DIFF
--- a/102/features/12-feature-linux-systray-example.patch
+++ b/102/features/12-feature-linux-systray-example.patch
@@ -8,18 +8,15 @@ diff --git a/third_party/appindicator/Makefile b/third_party/appindicator/Makefi
 new file mode 100644
 --- /dev/null
 +++ b/third_party/appindicator/Makefile
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,31 @@
 +# Code from https://github.com/AyatanaIndicators/libayatana-appindicator
 +# and related repositories.
 +# See https://github.com/AyatanaIndicators/libayatana-appindicator/issues/46 for build instructions.
 +# You need: sudo aptitude install libdbusmenu-gtk3-dev
 +
-+CFLAGS=`pkg-config --cflags gtk+-3.0 glib-2.0` \
-+  -I/usr/include/libdbusmenu-glib-0.4/ \
-+  -I/usr/include/libdbusmenu-gtk3-0.4/ \
-+  -I/usr/include/glib-2.0
++CFLAGS=`pkg-config --cflags dbusmenu-gtk3-0.4` \
 +
-+LDFLAGS=`pkg-config --libs gtk+-3.0 glib-2.0` -ldbusmenu-glib -ldbusmenu-gtk3
++LDFLAGS=`pkg-config --libs dbusmenu-gtk3-0.4`
 +
 +OBJECTS=betterbird-systray-icon.o \
 +  app-indicator.o \


### PR DESCRIPTION
I am packaging betterbird for NixOS and that has no /usr/ directory.