### PR TITLE
fix typo in pl.cmd

### DIFF
--- a/115/scripts/pl.cmd
+++ b/115/scripts/pl.cmd
@@ -92,5 +92,5 @@ set lecho=C:\mozilla-build\msys\bin\lessecho.exe
 %lecho% "    .accesskey = n"                          >> localization\pl\messenger\preferences\preferences.ftl
 
 :: New string from bug 1823274. The Thunderbird folks where negligent and didn't refresh l10n so it's missing everywhere :-(
-%lecho% "context-menu-cancel-msg ="      >> localization\pt\messenger\messenger.ftl
-%lecho% "    .label = Wycofaj wiadomość" >> localization\pt\messenger\messenger.ftl
+%lecho% "context-menu-cancel-msg ="      >> localization\pl\messenger\messenger.ftl
+%lecho% "    .label = Wycofaj wiadomość" >> localization\pl\messenger\messenger.ftl


### PR DESCRIPTION
This is blocking the flatpak build of 115.2.3-bb12.

Can you please apply a new tag after merging this? Thanks!