### PR TITLE
Fix appdata.xml for flatpak build

### DIFF
--- a/metadata/eu.betterbird.Betterbird.128.appdata.xml
+++ b/metadata/eu.betterbird.Betterbird.128.appdata.xml
@@ -3,7 +3,7 @@
   <id>eu.betterbird.Betterbird</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Betterbird</name>
-  <summary>Betterbird is a soft fork of Mozilla Thunderbird. Simply better.</summary>
+  <summary>Soft fork of Mozilla Thunderbird</summary>
   <description>
     <p>Betterbird is a fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will. Betterbird is better than Thunderbird in three ways: It contains new features exclusive to Betterbird, it contains bug fixes exclusive to Betterbird and it contains fixes that Thunderbird may ship at a later stage.</p>
   </description>
@@ -53,9 +53,11 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/Betterbird/thunderbird-patches/main/metadata/screenshot_light.png</image>
+      <caption>Main window in light mode</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/Betterbird/thunderbird-patches/main/metadata/screenshot_dark.png</image>
+      <caption>Main window in dark mode</caption>
     </screenshot>
   </screenshots>
 

--- a/metadata/eu.betterbird.Betterbird.128.appdata.xml
+++ b/metadata/eu.betterbird.Betterbird.128.appdata.xml
@@ -61,13 +61,18 @@
     </screenshot>
   </screenshots>
 
-  <mimetypes>
-    <mimetype>message/rfc822</mimetype>
-    <mimetype>x-scheme-handler/mailto</mimetype>
-    <mimetype>text/calendar</mimetype>
-    <mimetype>text/vcard</mimetype>
-    <mimetype>text/x-vcard</mimetype>
-  </mimetypes>
+  <provides>
+    <mediatype>message/rfc822</mediatype>
+    <mediatype>x-scheme-handler/mailto</mediatype>
+    <mediatype>application/x-xpinstall</mediatype>
+    <mediatype>application/x-extension-ics</mediatype>
+    <mediatype>text/calendar</mediatype>
+    <mediatype>text/vcard</mediatype>
+    <mediatype>text/x-vcard</mediatype>
+    <mediatype>x-scheme-handler/webcal</mediatype>
+    <mediatype>x-scheme-handler/webcals</mediatype>
+    <mediatype>x-scheme-handler/mid</mediatype>
+  </provides>
 
   <!-- distributors: yes, this is a real person -->
   <update_contact>builds@betterbird.eu</update_contact>

--- a/metadata/eu.betterbird.Betterbird.appdata.xml
+++ b/metadata/eu.betterbird.Betterbird.appdata.xml
@@ -3,7 +3,7 @@
   <id>eu.betterbird.Betterbird</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Betterbird</name>
-  <summary>Betterbird is a soft fork of Mozilla Thunderbird. Simply better.</summary>
+  <summary>Soft fork of Mozilla Thunderbird</summary>
   <description>
     <p>Betterbird is a fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will. Betterbird is better than Thunderbird in three ways: It contains new features exclusive to Betterbird, it contains bug fixes exclusive to Betterbird and it contains fixes that Thunderbird may ship at a later stage.</p>
   </description>
@@ -50,9 +50,11 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/Betterbird/thunderbird-patches/main/metadata/screenshot_light.png</image>
+      <caption>Main window in light mode</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/Betterbird/thunderbird-patches/main/metadata/screenshot_dark.png</image>
+      <caption>Main window in dark mode</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Flatpak builder seems to be pickier when validating the appdata.xml than it used to be:

https://buildbot.flathub.org/#/builders/30/builds/12514

I cannot build the flatpak using the current appdata.xml because validation fails:
- summary is longer than 35 characters
- summary ends with a period
- screenshots are missing captions
- (128 only) mimetypes tag is deprecated

Please consider updating the appdata.xml as suggested in this PR.