### PR TITLE
fix(128): added missing supported desktop (Pop!_OS)

### DIFF
--- a/128/features/12+13-feature-linux-systray-incl-minimise.patch
+++ b/128/features/12+13-feature-linux-systray-incl-minimise.patch
@@ -36,8 +36,8 @@ diff --git a/mail/app/profile/all-thunderbird.js b/mail/app/profile/all-thunderb
  pref("mail.minimizeToTray", false);
  #endif
 +#ifdef UNIX_BUT_NOT_MAC
-+pref("mail.systemTrayNoTooltip", "gnome,ubuntu:gnome");
-+pref("mail.minimizeToTray.supportedDesktops", "kde,gnome,xfce,mate");
++pref("mail.systemTrayNoTooltip", "gnome,ubuntu:gnome,pop:gnome");
++pref("mail.minimizeToTray.supportedDesktops", "kde,gnome,pop:gnome,xfce,mate");
 +pref("mail.minimizeToTray.desktopsGtkWindowPresentWithTime", "mate");
 +#endif
  


### PR DESCRIPTION
Hi! When I was testing Thunderbird as my main mail client, I've stumbled on one small but pretty annoying problem: I can't hide the app to the system tray. Then I started searching for solution and found about Betterbird.

To cut the long story short, I tried it before, because it said in the feature table that it supports it, but it didn't work. Today I tried to do this again — same thing. Pretty sadge, but I digged a bit deeper and found the `./betterbird -p` command (I guess `./betterbird` should be enough), which then gave me the warning about not being able to minimize the app to tray.

It identified the desktop as `pop:gnome`, after which I realized, that it's probably an oversight (i.e., no one tested on Pop!_OS), as the `gnome` platform is listed as supported. So I edited the config with a hope that it will work, and it did! Now I'm pretty stocked about using Betterbird. And with the close-to-tray plugin the combo is complete. Though one nitpick is that I have to double-click the tray icon to show the app instead of just a single click.

I've only the latest version from the website download page on Pop!_OS 22.04, but I suspect it will work on any version where `gnome` desktop works.
