### PR TITLE
Use portable option for determining architecture

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -53,19 +53,8 @@ else
   ARCHIVE_SUFFIX="tar.bz2"
 fi
 UNAME=$(uname)
-# uname -i doesn't work on Mac.
-UNAME_ARCH="unknown"
-if [ "$UNAME" = "Linux" ]; then
-  UNAME_FULL=$(uname -a)
-  UNAME_ARCH=$(uname -i)
-  # Hack for Debian 11 Bullseye on Amazon EC2 image.
-  if [[ "$UNAME_FULL" == *"aarch64"* ]] && [ "$UNAME_ARCH" = "unknown" ]; then
-    UNAME_ARCH="aarch64"
-  fi
-fi
-if [ "$UNAME" = "Darwin" ]; then
-  UNAME_ARCH=$(uname -m)
-fi
+# Note: uname -i is non-portable, even across GNU/Linux distributions
+UNAME_ARCH=$(uname -m)
 # Windows: Cater for newer and older MozillaBuild: MINGW32_NT-6.2 or MSYS_NT-10
 if [[ "$UNAME" == *"_NT-"* ]]; then
   UNAME="Windows"


### PR DESCRIPTION
As per uname's man page the `-i` option is non-portable, even across
GNU/Linux distributions, whereas `uname -m` works across distributions.
