### PR TITLE
fix: add betterbirdUpdateStatusContainer div with min-height to aboutDialog page

### DIFF
--- a/140/misc/03-misc-update-check.patch
+++ b/140/misc/03-misc-update-check.patch
@@ -1,7 +1,7 @@
 # HG changeset patch
 # User Betterbird <betterbird@betterbird.eu>
 # Date 1749645852 -7200
-# Parent  8873d8c3254e9ba76ce3aef0875fb4d06174fcc4
+# Parent  a8da73129f9a7b94dcd18e6065e7fcae0b8c0896
 Misc: Add update check and fix release notes link.
 * * *
 Misc: Startup update check.
@@ -52,7 +52,7 @@ diff --git a/mail/app/profile/all-thunderbird.js b/mail/app/profile/all-thunderb
 diff --git a/mail/base/content/aboutDialog.css b/mail/base/content/aboutDialog.css
 --- a/mail/base/content/aboutDialog.css
 +++ b/mail/base/content/aboutDialog.css
-@@ -174,4 +174,12 @@ body {
+@@ -174,4 +174,20 @@ body {
    &:not(.noUpdatesFound, .apply, .checkingForUpdates, .downloading, .applying, .restarting) {
      display: none;
    }
@@ -64,6 +64,14 @@ diff --git a/mail/base/content/aboutDialog.css b/mail/base/content/aboutDialog.c
 +#checkingFailed,
 +#manualUpdate {
 +  display: none;
++}
++
++/* Set min-height relative to the font-size of the root element for the flex hbox
++ * container so that the initial window size can support dynamic display updates
++ * to the child status divs without dimension overflow. The value of 1.5 matches
++ * the parent #aboutDialog line-height. */
++#updateBox {
++  min-height: 1.5rem;
 +}
 diff --git a/mail/base/content/aboutDialog.js b/mail/base/content/aboutDialog.js
 --- a/mail/base/content/aboutDialog.js
@@ -207,7 +215,7 @@ diff --git a/mail/base/content/aboutDialog.xhtml b/mail/base/content/aboutDialog
 diff --git a/mail/components/MailGlue.sys.mjs b/mail/components/MailGlue.sys.mjs
 --- a/mail/components/MailGlue.sys.mjs
 +++ b/mail/components/MailGlue.sys.mjs
-@@ -762,8 +762,9 @@ MailGlue.prototype = {
+@@ -766,8 +766,9 @@ MailGlue.prototype = {
     * but it will not make it happen later (and out of order) compared
     * to the other ones scheduled together.
     */
@@ -217,7 +225,7 @@ diff --git a/mail/components/MailGlue.sys.mjs b/mail/components/MailGlue.sys.mjs
        {
          task() {
            // This module needs to be loaded so it registers to receive
-@@ -895,8 +896,13 @@ MailGlue.prototype = {
+@@ -899,8 +900,13 @@ MailGlue.prototype = {
          },
        },
        {
@@ -231,7 +239,7 @@ diff --git a/mail/components/MailGlue.sys.mjs b/mail/components/MailGlue.sys.mjs
            // idle tasks.
            ChromeUtils.idleDispatch(() => {
              Services.obs.notifyObservers(
-@@ -1026,8 +1032,108 @@ MailGlue.prototype = {
+@@ -1030,8 +1036,108 @@ MailGlue.prototype = {
        linkHandled.data = true;
      }
    },


### PR DESCRIPTION
**Thanks for your efforts with this project!**

This fix prevents resize overflow with customized builds like the Flatpak *distribution.ini* `about=` modification. For example, the update check pushes text outside of the default window dimensions:
![betterbird](https://github.com/user-attachments/assets/4eb9921d-e235-4605-8ac6-e4c66f7db665)
The fixed version is properly resized:
<img width="1001" height="552" alt="image" src="https://github.com/user-attachments/assets/16e679bb-7e15-4ce2-be43-2663a7fdafb5" />