### PR TITLE
Update 03-misc-update-check.patch to use CSS max() calculation for min-height to reduce status update overflow.

### DIFF
--- a/140/misc/03-misc-update-check.patch
+++ b/140/misc/03-misc-update-check.patch
@@ -66,12 +66,12 @@ diff --git a/mail/base/content/aboutDialog.css b/mail/base/content/aboutDialog.c
 +  display: none;
 +}
 +
-+/* Set min-height relative to the font-size of the root element for the flex hbox
-+ * container so that the initial window size can support dynamic display updates
-+ * to the child status divs without dimension overflow. The value of 1.5 matches
-+ * the parent #aboutDialog line-height. */
++/* Set min-height to the maximum value of: the root element font-size (rem),
++ * the calculated font-size of the selected element (em), or the line-height
++ * of the element. This attempts to reduce overflow when a child div is
++ * dynamically activated. */
 +#updateBox {
-+  min-height: 1.5rem;
++  min-height: max(1rem, 1em, 1lh);
 +}
 diff --git a/mail/base/content/aboutDialog.js b/mail/base/content/aboutDialog.js
 --- a/mail/base/content/aboutDialog.js


### PR DESCRIPTION
Here is a better alternative to enforcing `1.5rem` using the [CSS max() calculation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/max) to set `min-height` based on whichever is the largest positive value: the **root element font-size** (_rem_), the calculated **font-size of the selected element** (_em_), or the **line-height of the element**.