### PR TITLE
Add VCS browser URL to appdata.xml

### DIFF
--- a/metadata/eu.betterbird.Betterbird.140.appdata.xml
+++ b/metadata/eu.betterbird.Betterbird.140.appdata.xml
@@ -26,7 +26,8 @@
   <url type="help">https://www.betterbird.eu/support/</url>
   <url type="donation">https://www.betterbird.eu/donate/</url>
   <url type="translate">https://github.com/Betterbird/thunderbird-patches</url>
-
+  <url type="vcs-browser">https://github.com/Betterbird/thunderbird-patches</url>
+  
   <launchable type="desktop-id">eu.betterbird.Betterbird.desktop</launchable>
  
   <releases>


### PR DESCRIPTION
Flathub recommends adding vcs-browser for open source projects as described [here](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url).