### PR TITLE
Updates for automated Debian package conversion

### DIFF
--- a/140/branding/02-branding.patch
+++ b/140/branding/02-branding.patch
@@ -66,7 +66,7 @@ diff --git a/mail/branding/betterbird/configure.sh b/mail/branding/betterbird/co
 diff --git a/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml b/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml
 --- a/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml
 +++ b/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml
-@@ -1,43 +1,33 @@
+@@ -1,43 +1,34 @@
  <?xml version="1.0" encoding="UTF-8"?>
  <component type="desktop-application">
 -  <id>net.thunderbird.Thunderbird</id>
@@ -74,6 +74,7 @@ diff --git a/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml b/mai
    <metadata_license>CC0-1.0</metadata_license>
 -  <name>Thunderbird</name>
 -  <summary>Thunderbird is a free and open source email, newsfeed, chat, and calendaring client</summary>
++  <launchable type="desktop-id">eu.betterbird.Betterbird.desktop</launchable>
 +  <name>Betterbird</name>
 +  <summary>Betterbird is a soft-fork of Mozilla Thunderbird. Simply better.</summary>
    <description>
@@ -123,7 +124,7 @@ diff --git a/mail/branding/betterbird/eu.betterbird.Betterbird.appdata.xml b/mai
    <mimetypes>
      <mimetype>message/rfc822</mimetype>
      <mimetype>x-scheme-handler/mailto</mimetype>
-@@ -46,6 +36,6 @@
+@@ -46,6 +37,6 @@
      <mimetype>text/x-vcard</mimetype>
    </mimetypes>
  

--- a/140/branding/05-branding-moz.patch
+++ b/140/branding/05-branding-moz.patch
@@ -1,0 +1,24 @@
+Make "./mach install" use the correct directory/symlink names.
+
+--- a/config/baseconfig.mk
++++ b/config/baseconfig.mk
+@@ -2,7 +2,7 @@
+ # directly in python/mozbuild/mozbuild/base.py for gmake validation.
+ # We thus use INCLUDED_AUTOCONF_MK to enable/disable some parts depending
+ # whether a normal build is happening or whether the check is running.
+-installdir = $(libdir)/$(MOZ_APP_NAME)
++installdir = $(libdir)/$(MOZ_PKG_APPNAME)
+ includedir := $(includedir)/$(MOZ_APP_NAME)
+ idldir = $(datadir)/idl/$(MOZ_APP_NAME)
+ sdkdir = $(libdir)/$(MOZ_APP_NAME)-devel
+--- a/toolkit/mozapps/installer/packager.mk
++++ b/toolkit/mozapps/installer/packager.mk
+@@ -173,7 +173,7 @@ endif
+ 	  (cd $(DESTDIR)$(installdir) && tar -xf -)
+ 	$(NSINSTALL) -D $(DESTDIR)$(bindir)
+ 	$(RM) -f $(DESTDIR)$(bindir)/$(MOZ_APP_NAME)
+-	ln -s $(installdir)/$(MOZ_APP_NAME) $(DESTDIR)$(bindir)
++	ln -s $(installdir)/$(MOZ_PKG_APPNAME) $(DESTDIR)$(bindir)
+ 
+ upload:
+ 	$(PYTHON3) -u $(MOZILLA_DIR)/build/upload.py --base-path $(DIST) $(UPLOAD_FILES)

--- a/140/branding/05-branding.patch
+++ b/140/branding/05-branding.patch
@@ -329,6 +329,18 @@ diff --git a/mail/installer/windows/nsis/shared.nsh b/mail/installer/windows/nsi
      ${WriteRegStr2} $1 "$0" "URLInfoAbout" "${URLInfoAbout}" 0
      ${WriteRegStr2} $1 "$0" "URLUpdateInfo" "${URLUpdateInfo}" 0
      ${WriteRegDWORD2} $1 "$0" "NoModify" 1 0
+diff --git a/mail/locales/Makefile.in b/mail/locales/Makefile.in
+--- a/mail/locales/Makefile.in
++++ b/mail/locales/Makefile.in
+@@ -22,7 +22,7 @@ PWD := $(CURDIR)
+ 
+ ZIP_IN ?= $(ABS_DIST)/$(PACKAGE)
+ 
+-MOZ_LANGPACK_EID=langpack-$(AB_CD)@thunderbird.mozilla.org
++MOZ_LANGPACK_EID=langpack-$(AB_CD)@betterbird.eu
+ 
+ NON_OMNIJAR_FILES = defaults/messenger/mailViews.dat
+ 
 diff --git a/mail/moz.configure b/mail/moz.configure
 --- a/mail/moz.configure
 +++ b/mail/moz.configure

--- a/140/mozconfig-Linux
+++ b/140/mozconfig-Linux
@@ -1,7 +1,5 @@
 ac_add_options --enable-application=comm/mail
-ac_add_options --with-branding=comm/mail/branding/betterbird
 ac_add_options --disable-updater
-ac_add_options --disable-crashreporter
 ac_add_options --enable-tests
 ac_add_options --without-wasm-sandboxed-libraries
 
@@ -12,26 +10,22 @@ ac_add_options --allow-addon-sideload
 # Fix fuzzy fonts by enabling EGL.
 ac_add_options --enable-default-toolkit=cairo-gtk3-wayland
 
-# Disable enforcing that add-ons are signed.
+# Disable enforcing that add-ons are signed by the trusted root.
+# (Signatures are still checked, however; see MOZ_ADDON_SIGNING)
 MOZ_REQUIRE_SIGNING=
-MOZ_REQUIRE_ADDON_SIGNING=0
 
 ac_add_options --enable-official-branding
-
-# For NSS symbols
-export MOZ_DEBUG_SYMBOLS=1
-
-# Set the WM_CLASS referenced in the .desktop file.
-export MOZ_APP_REMOTINGNAME=eu.betterbird.Betterbird
 
 # Needed to enable breakpad in application.ini
 # The preceding comment appears all over the Mozilla repos, however it is misleading.
 # "Official" (server) builds, as opposed to local builds, should have nothing to do
 # with "breakpad" (https://chromium.googlesource.com/breakpad/) crash reporting.
 # In any case, we don't want a local build.
-export MOZILLA_OFFICIAL=1
 
-export MOZ_TELEMETRY_REPORTING=  # No telemetry.
+# This option is named somewhat misleadingly. It specifies that we want
+# a "server" (publicly distributable) build, not a "local" (private-use)
+# one. The latter is intended for development/testing purposes only.
+export MOZILLA_OFFICIAL=1
 
 # Used for Linux to create small launcher executable for file browsers.
 # See https://hg.mozilla.org/mozilla-central/rev/3cbbfc5127e4 for details.
@@ -39,3 +33,18 @@ export MOZ_NO_PIE_COMPAT=1
 
 # We're using 8 cores now.
 mk_add_options MOZ_MAKE_FLAGS="-j8"
+
+
+#### Betterbird required build configuration
+
+# Use Betterbird branding.
+ac_add_options --with-branding=comm/mail/branding/betterbird
+
+# Don't report Betterbird crashes to the Thunderbird infrastructure.
+ac_add_options --disable-crashreporter
+
+# Don't send Betterbird telemetry to the Thunderbird infrastructure.
+export MOZ_TELEMETRY_REPORTING=
+
+# Set the WM_CLASS referenced in the .desktop file.
+export MOZ_APP_REMOTINGNAME=eu.betterbird.Betterbird

--- a/140/series-moz
+++ b/140/series-moz
@@ -1,4 +1,5 @@
 branding/02-branding-moz.patch
+branding/05-branding-moz.patch
 branding/05b-branding-localised-installer-moz.patch
 branding/08-branding-moz.patch
 ## 09-branding-moz.patch - retired in favour of 9c.


### PR DESCRIPTION
This is a follow-up to #544, making some tweaks to the patches and Linux mozconfig to smooth the way for an automated conversion of the Debian `thunderbird` package into a `betterbird` one.

This PR has four relatively granular commits, as I figured you'd prefer that approach. Let me know if anything here is not to your liking, and if you'd like me to update the other mozconfig files in a similar way. Sorry for the wait.